### PR TITLE
Return 406 when password and repassword do not match

### DIFF
--- a/src/main/java/ca/sait/vezorla/controller/CustomerRestController.java
+++ b/src/main/java/ca/sait/vezorla/controller/CustomerRestController.java
@@ -2,6 +2,7 @@ package ca.sait.vezorla.controller;
 
 import ca.sait.vezorla.controller.util.CustomerClientUtil;
 import ca.sait.vezorla.exception.InvalidInputException;
+import ca.sait.vezorla.exception.PasswordMismatchException;
 import ca.sait.vezorla.exception.UnableToSaveException;
 import ca.sait.vezorla.model.*;
 import ca.sait.vezorla.repository.DiscountRepo;
@@ -260,7 +261,7 @@ public class CustomerRestController {
         //Check if password and rePassword are the same
         assert password != null;
         if (!password.equals(rePassword))
-            return created;
+            throw new PasswordMismatchException();
 
         //Check if account exists
         Optional<Account> newAccount = userServices.findAccountByEmail(email);

--- a/src/main/java/ca/sait/vezorla/exception/PasswordMismatchException.java
+++ b/src/main/java/ca/sait/vezorla/exception/PasswordMismatchException.java
@@ -1,0 +1,18 @@
+package ca.sait.vezorla.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when the password and re-password are not matching
+ * This is done for create account
+ * Returns 406 HttpStatus
+ *
+ * @author: matthewjflee
+ */
+@ResponseStatus(value = HttpStatus.NOT_ACCEPTABLE)
+public class PasswordMismatchException extends RuntimeException{
+    public PasswordMismatchException() {
+        super("Password and re-password do not match!");
+    }
+}


### PR DESCRIPTION
406 is now returned instead of `false` when the password and repassword do not match

![image](https://user-images.githubusercontent.com/42304224/77003310-be41a880-6922-11ea-88e8-938227e7bf67.png)


![image](https://user-images.githubusercontent.com/42304224/77003324-c4378980-6922-11ea-8d6e-fe1bebb1cdb9.png)
